### PR TITLE
fix: Prefer wayland for Emacs daemon on Linux

### DIFF
--- a/atomic-chrome.el
+++ b/atomic-chrome.el
@@ -647,7 +647,10 @@ positioning the frame near the area being edited."
           ;; not an emacsclient frame (#10).
           ((and (memq system-type '(gnu gnu/linux gnu/kfreebsd))
                 (not (frame-parameter (selected-frame) 'client)))
-           (make-frame-on-display (getenv "DISPLAY") frame-params))
+           (make-frame-on-display
+            (or (and (featurep 'pgtk) (getenv "WAYLAND_DISPLAY"))
+                (getenv "DISPLAY"))
+            frame-params))
           (t
            (make-frame frame-params)))))
 


### PR DESCRIPTION
This follows the logic chosen by emacsclient itself when no --display argument is given, see https://github.com/emacsmirror/emacs/blob/810e9d675ba484dabade1a9f30201d2848c5e2ea/lib-src/emacsclient.c#L633-L638

Related to #10.